### PR TITLE
NETseq refactor, modeling, peak calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Develop
+## 0.0.3
 
 ### Added
 - Added a log2 strand bias calculation as a possible coverage track
 - Calculation of the count of fragments for each contig
-- Allow two separate cutadapt runs to occur
+- Allow two separate cutadapt runs to occur for sequencing kits that require
+  sequential trimming
 - Added a rule to generate annotation files easily with `run_annotations`
 - Added the ability to specify relative coordinates in `bwtools_query`
 - Unstranded Peak calling and motif calling
 - Modeling module with DESeq2 and stranded feature quant with HTseq-count
+- Ability to better set parameters for ChIP QC in config file
 
 ### Changed
 - Refactored `NETseq_pause_calling.py` for performance boost
@@ -24,6 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-paired end samples
 - Fixed issue with `multiqc` report not properly reporting pre and post trim
   fastqc reports
+- Fixed issue with bamPEFragmentSize would attempt to run on single end data
+- Fixed issue with trimmomatic not properly running for single end data
+- Fixed issue with spearman correlation calculations failing on updated coverage
+  files from bwtools
+- Fixed issue with NETseq pause calling failing when NaNs were present in data
+  by coercing all NaNs to zeros
+- Fixed issue where pulling sequences from bed files near genome boundaries
+  would fail. Updated to consider all chromosomes as circular.
+- Fixed an issue where NETseq logos would display information content on
+  a non-standard scale. Fixed scaling to be 0 to 2.0 bits
+- Fixed an issue where numpy deprecations impact deeptools quality control. Set
+  a lower version of numpy in environment files for quality control
 
 ## 0.0.2
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,6 +45,11 @@ preprocessing:
     cutadapt_pe:
         cut_param_string:
             value: "-a AGATCGGAAGAGCACACGTCTGAACTCCAGTCA -A AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT"
+        # some stranded sequence libraries require two cutting steps in this
+        # case we needed to remove the last five bases of R1 and the first five
+        # bases of R2 after cutting the adaptors off
+        cut2_param_string:
+            value: "-u -5 -U 5"
     # Control the parameter string from trimmomatic
     trimmomatic_pe:
         trim_param_string:
@@ -97,7 +102,7 @@ coverage_and_norm:
         bamCoverage_param_string:
             # Want only the 5' end of the read (which is really the
             # 3' end of the NET-seq read)
-            value: "--samFlagInclude 67 --Offset 1"
+            column: "bamCoverage_params"
     bwtools_spike_scale:
         # This controls how the spike-in regions are used to scale the
         # data when scaling to a spike-in.
@@ -164,14 +169,14 @@ coverage_and_norm:
             value: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
         # how many regions to look at?
         number_of_regions:
-            value: 20
+            value: 10
     bwtools_query_scale:
         # What regions to consider for a max scaling
         query_regions:
             value: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
         # How many regions to look at for max scaling
         number_of_regions:
-            value: 20
+            value: 10
 
     bwtools_multicompare:
         # Run these models by doing `snakemake --use-conda --cores
@@ -221,6 +226,24 @@ coverage_and_norm:
 quality_control:
     # what column to group samples by for ChIP-QC output plots?
     group_by: genome
+    # control how reads are filter for ALL samples
+    bamCoverage_params: " " 
+    # Determine sampling parameters for fingerprint plots. These are good
+    # defaults for E. coli
+    plotFingerprint:
+        binsize: 500
+        num_samps: 9200
+    # Determine bin size for coverage calcs. This controls PCA and correlation
+    # as well
+    multiBamSummary:
+        binsize: 1000
+    # Determine sampling parameters for coverage calculations
+    plotCoverage:
+        num_samps: 1000
+    bamPEFragSize:
+        bin_dist: 10000
+
+
 
 # Options to control peak calling
 peak_calling:
@@ -254,6 +277,37 @@ peak_calling:
         # automatically determined.
         macs2_param_string: 
             column: macs2_params
+
+# Options to control motif calling
+# run with run_motif_calling
+motif_calling:
+    # Can make different models to try out different motif callers or params
+    macs2_all:
+        # Which motif caller? Supports meme and streme
+        motif_caller: "streme"
+        # Which samples to run on?
+        filter: 'not input_sample.isnull()'
+        # Which file to run on?
+        filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
+        # Parameters for the background markov model
+        get_markov_param_string:
+            value: "-dna -m 2"
+        # Parameters for the streme motif caller
+        streme_param_string:
+            value: "--dna --minw 8 --maxw 30 --nmotifs 2"
+        # Parameters controlling how the sequences are pulled from the bed
+        get_peak_seqs_param_string:
+            value: "--upstream 30 --downstream 30"
+
+    # Same thing but running a different motif finder
+    macs2_all_meme:
+        motif_caller: "meme"
+        filter: 'not input_sample.isnull()'
+        filesignature: "results/peak_calling/macs2_all/macs2/%s_summits.bed"
+        get_markov_param_string:
+            value: "-dna -m 0"
+        get_peak_seqs_param_string:
+            value: "--upstream 30 --downstream 30"
 
 # Options to control variant calling. I.e. running breseq on the input samples
 variant_calling:
@@ -302,7 +356,7 @@ postprocessing:
             # which regions to use?
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use? Note we can use a different set than Model 1
-            filesignature: "results/coverage_and_norm/bwtools_compare/%s_minus_median_ratio_querysub_queryscale.bw"
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_minus_median_ratio_querysub.bw"
             # what resolution to query data (shouldn't be lower than the
             # resolution of your file, think of this as a sampling rate, no 
             # averaging is done over the bins)
@@ -327,7 +381,7 @@ postprocessing:
             # which regions to use?
             regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
             # which files to use?
-            filesignature: "results/coverage_and_norm/bwtools_compare/%s_plus_median_ratio_querysub_queryscale.bw"
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_plus_median_ratio_querysub.bw"
             # what resolution to query data (shouldn't be lower than the
             # resolution of your file
             res : 5
@@ -385,3 +439,47 @@ postprocessing:
             # what fraction of NaNs can be in a region and still report a value?
             frac_na: 0.20
 
+        # Model 6 - look at the average strand ratio at each gene
+        all_genes_mean_strand_ratio:
+            # which regions to use?
+            regions: "results/alignment/process_genbank/U00096.3/U00096.3.bed"
+            # which files to use? Note we can use a different set than Model 1
+            filesignature: "results/coverage_and_norm/bwtools_compare/%s_log2strandratio.bw"
+            # what resolution to query data (shouldn't be lower than the
+            # resolution of your file, think of this as a sampling rate, no 
+            # averaging is done over the bins)
+            res : 5
+            # How do you want to summarize your data? (identity gives every data
+            # point in tidy format, single allows for a single number summary)
+            summarize: "single"
+            filter: "input_sample.isnull() or not input_sample.isnull()"
+            # What single number summary do you want (mean, median, max, min,
+            # etc.)
+            # only defined when summarize is "single"
+            summary_func: "mean"
+            # what fraction of NaNs can be in a region and still report a value?
+            frac_na: 0.20
+
+# Control for NETseq submodule
+NETseq:
+    pause_calling:
+        test:
+            model_type: "Genomewide"
+            NETseq_pause_params: "--method Larson --circular True --filter cov --cov_cutoff 1"
+            filter: "seq_method == 'NETseq'"
+            wsize: 100
+
+# Control for the modeling submodule
+modeling:
+    # Specify a specific model you want to run
+    by_condition:
+        # Which samples?
+        filter: "not input_sample.isnull()"
+        # How should HTseq count features?
+        HTseq_params: "-s reverse -a 0 -i ID -t gene"
+        # Which features should be counted?
+        regions: "results/alignment/combine_gff/U00096.3/U00096.3.gff"
+        # Whats the full model?
+        full: "~ genotype"
+        # Whats the reduced model?
+        reduced: "~ 1"

--- a/pep/test_samples.csv
+++ b/pep/test_samples.csv
@@ -1,10 +1,10 @@
 sample_name,filenameR1,filenameR2,file_path,input_sample,genotype,genome,library_type,bamCoverage_params,macs2_params,seq_method
-genotypeA_rep1_ext,genotypeA_rep1_ext_R1.fastq.gz,genotypeA_rep1_ext_R2.fastq.gz,source1,genotypeA_rep1_inp,A,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE --broad,bisulfite
-genotypeA_rep2_ext,genotypeA_rep2_ext_R1.fastq.gz,genotypeA_rep2_ext_R2.fastq.gz,source1,genotypeA_rep2_inp,A,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE --broad,
+genotypeA_rep1_ext,genotypeA_rep1_ext_R1.fastq.gz,genotypeA_rep1_ext_R2.fastq.gz,source1,genotypeA_rep1_inp,A,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE,bisulfite
+genotypeA_rep2_ext,genotypeA_rep2_ext_R1.fastq.gz,genotypeA_rep2_ext_R2.fastq.gz,source1,genotypeA_rep2_inp,A,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE,
 genotypeA_rep1_inp,genotypeA_rep1_inp_R1.fastq.gz,genotypeA_rep1_inp_R2.fastq.gz,source1,,A,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,,
 genotypeA_rep2_inp,genotypeA_rep2_inp_R1.fastq.gz,genotypeA_rep2_inp_R2.fastq.gz,source1,,A,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,,
-genotypeB_rep1_ext,genotypeB_rep1_ext_R1.fastq.gz,genotypeB_rep1_ext_R2.fastq.gz,source1,genotypeB_rep1_inp,B,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE --broad,
-genotypeB_rep2_ext,genotypeB_rep2_ext_R1.fastq.gz,genotypeB_rep2_ext_R2.fastq.gz,source1,genotypeB_rep2_inp,B,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE --broad,
+genotypeB_rep1_ext,genotypeB_rep1_ext_R1.fastq.gz,genotypeB_rep1_ext_R2.fastq.gz,source1,genotypeB_rep1_inp,B,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE,
+genotypeB_rep2_ext,genotypeB_rep2_ext_R1.fastq.gz,genotypeB_rep2_ext_R2.fastq.gz,source1,genotypeB_rep2_inp,B,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,-f BAMPE,
 genotypeB_rep1_inp,genotypeB_rep1_inp_R1.fastq.gz,genotypeB_rep1_inp_R2.fastq.gz,source1,,B,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,,
 genotypeB_rep2_inp,genotypeB_rep2_inp_R1.fastq.gz,genotypeB_rep2_inp_R2.fastq.gz,source1,,B,U00096.3,rf-stranded,--samFlagInclude 67 --extendReads,,
-genotypeA_rep2_ext_se,genotypeA_rep2_ext_R1.fastq.gz,,source1,genotypeA_rep2_inp,A,U00096.3,rf-stranded, ,-f BAM --broad,
+genotypeA_rep2_ext_se,genotypeA_rep2_ext_R1.fastq.gz,,source1,genotypeA_rep2_inp,A,U00096.3,rf-stranded, --Offset 1,-f BAM,NETseq

--- a/workflow/envs/coverage_and_norm.yaml
+++ b/workflow/envs/coverage_and_norm.yaml
@@ -2,7 +2,7 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - numpy=1.19.0
-    - scipy=1.5.2
+    - numpy>=1.19.0
+    - scipy>=1.5.2
     - statsmodels
-    - deeptools=3.5.0
+    - deeptools>=3.5.1

--- a/workflow/envs/modeling.yaml
+++ b/workflow/envs/modeling.yaml
@@ -5,3 +5,4 @@ dependencies:
     - r-tidyverse >=1.3
     - bioconductor-deseq2
     - bioconductor-biocparallel
+    - bioconductor-apeglm

--- a/workflow/envs/quality_control.yaml
+++ b/workflow/envs/quality_control.yaml
@@ -2,7 +2,8 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - fastqc=0.11.8
-    - deeptools=3.5.0
-    - multiqc=1.11.0
+    - numpy=1.19.0
+    - fastqc>=0.11.8
+    - deeptools=3.5.1
+    - multiqc>=1.11.0
 

--- a/workflow/rules/NETseq.smk
+++ b/workflow/rules/NETseq.smk
@@ -101,7 +101,7 @@ rule NETseq_pause_seqs:
         1
     shell:
         "zcat {input.bed} | python3 workflow/scripts/pull_seq_from_bed.py - {input.fasta} "
-        "--upstream {params.upstream} --downstream {params.downstream} "
+        "--upstream {params.upstream} --downstream {params.downstream} --circular "
         " 2> {log.stderr} | gzip >  {output}"
 
 rule NETseq_pause_logo:

--- a/workflow/rules/preprocessing.smk
+++ b/workflow/rules/preprocessing.smk
@@ -143,7 +143,7 @@ rule trimmomatic_se:
         stdout="results/preprocessing/logs/trimmomatic_se/{sample}_trim.log",
         stderr="results/preprocessing/logs/trimmomatic_se/{sample}_trim.err"
     shell:
-       "trimmomatic SE -phred33 {input.in1} "
+       "trimmomatic SE -phred33 {input.in1} {output} "
        "{params.trim_param_string} > {log.stdout} 2> {log.stderr}"
 
 rule trimmomatic_pe:

--- a/workflow/scripts/NETseq_pause_calling.py
+++ b/workflow/scripts/NETseq_pause_calling.py
@@ -389,8 +389,8 @@ def genomewide_fast(args):
     plus_strand = bwtools.pyBigWig.open(args.infile_plus)
     minus_strand = bwtools.pyBigWig.open(args.infile_minus)
 
-    arrays_plus = bwtools.bigwig_to_arrays(plus_strand, res = 1)
-    arrays_minus = bwtools.bigwig_to_arrays(minus_strand, res = 1)
+    arrays_plus = bwtools.bigwig_to_arrays(plus_strand, res = 1, nan_to_zero = True)
+    arrays_minus = bwtools.bigwig_to_arrays(minus_strand, res = 1, nan_to_zero = True)
     
     # initialize filters for which locations to consider
     starting_filters= {'+' : {}, '-' : {}}
@@ -471,8 +471,8 @@ def region_main(args):
     plus_strand = bwtools.pyBigWig.open(args.infile_plus)
     minus_strand = bwtools.pyBigWig.open(args.infile_minus)
 
-    arrays_plus = bwtools.bigwig_to_arrays(plus_strand, res = 1)
-    arrays_minus = bwtools.bigwig_to_arrays(minus_strand, res = 1)
+    arrays_plus = bwtools.bigwig_to_arrays(plus_strand, res = 1, nan_to_zero = True)
+    arrays_minus = bwtools.bigwig_to_arrays(minus_strand, res = 1, nan_to_zero = True)
 
     # function factory for different methods
     methods = {'bootstrap': multiprocess_bootstrap,

--- a/workflow/scripts/NETseq_plot_logo.R
+++ b/workflow/scripts/NETseq_plot_logo.R
@@ -6,7 +6,7 @@ print(args)
 d <- read_tsv(args[1], col_names = FALSE)
 p <- ggseqlogo(d)
 
-p <- p + theme_classic() 
+p <- p + theme_classic() + ylim(c(0, 2.0))
 p$scales$scales[[1]] <- scale_x_continuous(breaks = seq(1, 18, by = 1), 
                                            labels= c(seq(-13,-1,by=1), seq(1, 5, by = 1)))
 

--- a/workflow/scripts/bwtools.py
+++ b/workflow/scripts/bwtools.py
@@ -34,7 +34,7 @@ def write_arrays_to_bigwig(outfilename, arrays, chrm_dict, res = 1, dropNaNsandI
             outf.addEntries(names[the_finite], starts[the_finite], 
                     ends = ends[the_finite], values=this_array[the_finite])
 
-def bigwig_to_arrays(bw, res = None):
+def bigwig_to_arrays(bw, res = None, nan_to_zero = False):
     """
     Convert a bigwig to a dictionary of numpy arrays, one entry per contig
     
@@ -46,11 +46,11 @@ def bigwig_to_arrays(bw, res = None):
     """
     arrays = {}
     for chrm in bw.chroms().keys():
-        arrays[chrm] = contig_to_array(bw, chrm, res)
+        arrays[chrm] = contig_to_array(bw, chrm, res, nan_to_zero = nan_to_zero)
     return arrays
 
 
-def contig_to_array(bw, chrm, res = None):
+def contig_to_array(bw, chrm, res = None, nan_to_zero = False):
     """
     Convert single basepair bigwig information to a numpy array
     
@@ -69,6 +69,8 @@ def contig_to_array(bw, chrm, res = None):
     out_array = bw.values(chrm, 0, chrm_length, numpy=True)
     if res:
         out_array = out_array[::res]
+    if nan_to_zero:
+        out_array[np.isnan(out_array)] = 0
     return out_array
 
 

--- a/workflow/scripts/pull_seq_from_bed.py
+++ b/workflow/scripts/pull_seq_from_bed.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
     parser.add_argument('fasta_file', type=str, help = "fasta file to pull sequences from")
     parser.add_argument('--upstream', type=int, help = "amount upstream to pad sequence by. Default = 0", default = 0)
     parser.add_argument('--downstream', type=int, help = "amount downstream to pad sequence by. Default = 0", default = 0)
+    parser.add_argument('--circular', action = "store_true", help = "treat chromosomes as circular?")
 
     args = parser.parse_args()
     bed_file = args.bed_file
@@ -41,6 +42,6 @@ if __name__ == "__main__":
             this_end = this_end + downstream 
             rc = False
         chrm = genome.pull_entry(this_chrm)
-        seq = chrm.pull_seq(this_start, this_end, rc = rc)
+        seq = chrm.pull_seq(this_start, this_end, rc = rc, circ = args.circular)
         sys.stdout.write(seq + "\n")
 

--- a/workflow/scripts/region_level_spearmans.R
+++ b/workflow/scripts/region_level_spearmans.R
@@ -5,7 +5,7 @@ suppressMessages(library(tidyverse))
 # regions
 
 spearman_per_region <- function(d){
-    samples <- colnames(d %>% select(-c(region,coord)))
+    samples <- colnames(d %>% select(-c(chrm, region,coord)))
     out <- list()
     k <- 1
     # do every combination of samples only once
@@ -18,8 +18,10 @@ spearman_per_region <- function(d){
             # use syntax to get past tidy_eval issues
             samp1 <- samples[[i]]
             samp2 <- samples[[j]]
-            out[[k]] <- d %>% group_by(region) %>%
-                    summarize(cor = cor(!!sym(samp1), !!sym(samp2), method = "sp"),
+            print(samp1)
+            print(samp2)
+            out[[k]] <- d %>% group_by(chrm, region) %>%
+                    summarize(cor = cor(!!sym(samp1), !!sym(samp2), method = "sp", use = "na.or.complete"),
                               samp1 = samples[[i]],
                               samp2 = samples[[j]],
                               avg_samp1 = mean(!!sym(samp1), na.rm = TRUE),
@@ -34,7 +36,7 @@ spearman_per_region <- function(d){
 
 args <- commandArgs(trailingOnly = TRUE)
 
-ind <- read_tsv(args[1])
+ind <- read_tsv(args[1], na = "nan") %>% mutate(across(-c(chrm,region, coord), as.numeric))
 
 out <- spearman_per_region(ind)
 


### PR DESCRIPTION
### Added                                                                           
- Added a log2 strand bias calculation as a possible coverage track                 
- Calculation of the count of fragments for each contig                             
- Allow two separate cutadapt runs to occur for sequencing kits that require        
  sequential trimming                                                               
- Added a rule to generate annotation files easily with `run_annotations`           
- Added the ability to specify relative coordinates in `bwtools_query`              
- Unstranded Peak calling and motif calling                                         
- Modeling module with DESeq2 and stranded feature quant with HTseq-count           
- Ability to better set parameters for ChIP QC in config file                       
                                                                                    
### Changed                                                                         
- Refactored `NETseq_pause_calling.py` for performance boost                        
                                                                                    
### Bug fixes                                                                       
- Fixed issue with `workflow/rules/coverage_and_norm.smk` extending reads for       
  non-paired end samples                                                            
- Fixed issue with `multiqc` report not properly reporting pre and post trim        
  fastqc reports                                                                    
- Fixed issue with bamPEFragmentSize would attempt to run on single end data        
- Fixed issue with trimmomatic not properly running for single end data             
- Fixed issue with spearman correlation calculations failing on updated coverage 
  files from bwtools                                                                
- Fixed issue with NETseq pause calling failing when NaNs were present in data   
  by coercing all NaNs to zeros                                                     
- Fixed issue where pulling sequences from bed files near genome boundaries         
  would fail. Updated to consider all chromosomes as circular.                      
- Fixed an issue where NETseq logos would display information content on            
  a non-standard scale. Fixed scaling to be 0 to 2.0 bits                           
- Fixed an issue where numpy deprecations impact deeptools quality control. Set  
  a lower version of numpy in environment files for quality control    